### PR TITLE
Add missing <memory> for std::shared_ptr

### DIFF
--- a/Madplotlib.h
+++ b/Madplotlib.h
@@ -8,6 +8,9 @@
  * 2D plots inspired on matplotlib.
  */
 #pragma once
+
+#include <memory>
+
 #ifndef NO_EIGEN
 #include <Eigen/Dense>
 #endif


### PR DESCRIPTION
As the title says, it adds `<memory>` to fix the problem with `std::shared_ptr`.

Thanks for the repo!